### PR TITLE
Add application dependencies management

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,3 +64,22 @@ jobs:
         with:
           file: ./target/site/jacoco-ut/jacoco.xml
           name: codecov
+
+  applications-dependencies-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -U -B test --file pom.xml -Dtest=ApplicationsDependencyTest -Ddependencies.test.applications=1000

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -110,3 +110,22 @@ jobs:
         with:
           file: ./target/site/jacoco-ut/jacoco.xml
           name: codecov
+
+  applications-dependencies-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -U -B test --file pom.xml -Dtest=ApplicationsDependencyTest -Ddependencies.test.applications=1000

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,89 @@
+# Development
+
+## Required components
+
+### PostgreSQL
+
+First start a PostreSQL container in [Podman](https://podman.io/) executing:
+```Shell
+$ podman run -it --rm=true --memory-swappiness=0 \
+            --name postgres-application-inventory -e POSTGRES_USER=application_inventory \
+            -e POSTGRES_PASSWORD=application_inventory -e POSTGRES_DB=application_inventory_db \
+            -p 5432:5432 postgres:10.6
+```
+It works the same with Docker just replacing `podman` with `docker` in the above command.
+
+### Keycloak
+
+```Shell
+$ podman run -it --name keycloak --rm \
+            -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e KEYCLOAK_IMPORT=/tmp/keycloak/quarkus-realm.json \
+            -e DB_VENDOR=h2 -p 8180:8080 -p 8543:8443 -v ./src/main/resources/keycloak:/tmp/keycloak:Z \
+            jboss/keycloak:12.0.2
+```
+
+## Run the application in dev mode
+
+You can run your application in dev mode that enables live coding using:
+```Shell
+$ ./mvnw quarkus:dev
+```
+
+## Call endpoints in dev mode
+
+To do calls to application's endpoint while running it in dev mode, execute the following commands:
+```Shell
+$ export access_token=$(\
+    curl -X POST http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/token \
+    --user backend-service:secret \
+    -H 'content-type: application/x-www-form-urlencoded' \
+    -d 'username=alice&password=alice&grant_type=password' | jq --raw-output '.access_token' \
+ )
+$ curl -X GET 'http://localhost:8080/application-inventory/application?description=ser&sort=name' \
+  -H 'Accept: application/json' -H "Authorization: Bearer "$access_token |jq .
+```
+
+# Test
+
+## Test coverage
+
+To get the report of test coverage of the application's code it's a matter of activating the `coverage` Maven profile during `verify` Maven goal execution like in the following command:
+```shell
+$ ./mvnw verify -Pjacoco
+```
+
+at the end the report will be available opening in a browser the `target/site/jacoco-ut/index.html` file.
+
+# Database management
+
+> :rotating_light: Backup and Restore instructions are provided for development purposes and **NOT for production** usage :rotating_light:
+
+## Backup
+
+1. get the name of the PostgreSQL pod:
+   ```shell
+   $ kubectl get pods -l app.kubernetes.io/name=application-inventory-postgres -n tackle
+   ```
+1. retrieve the database's user using pod's name (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv`):
+   ```shell
+   $ kubectl exec application-inventory-postgres-7cf456bdb9-lxhjv -n tackle -- printenv POSTGRES_USER
+   ```
+1. dump the database **data only** (excluding `flyway_schema_history` table) using pod's name and database's user (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv` and `application_inventory`):
+   ```shell
+   $ kubectl exec application-inventory-postgres-7cf456bdb9-lxhjv -n tackle  -- /bin/bash -c "pg_dump -a -T flyway_schema_history -U application_inventory application_inventory_db" > $(date +%Y%m%d%H%M%S)_application_inventory_db_data.sql
+   ```
+
+## Restore
+
+1. get the name of the PostgreSQL pod:
+   ```shell
+   $ kubectl get pods -l app.kubernetes.io/name=application-inventory-postgres -n tackle
+   ```
+1. retrieve the database's user using pod's name (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv`):
+   ```shell
+   $ kubectl exec application-inventory-postgres-7cf456bdb9-lxhjv -n tackle -- printenv POSTGRES_USER
+   ```
+1. insert the values in the database using pod's name and database's user (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv` and `application_inventory`):
+   ```shell
+   $ cat 20210323195709_application_inventory_db_data.sql | kubectl exec -i application-inventory-postgres-7cf456bdb9-lxhjv -n tackle -- psql -U application_inventory -d application_inventory_db
+   ```

--- a/README.md
+++ b/README.md
@@ -2,94 +2,9 @@
 
 The Application Inventory application is used to manage a portfolio of applications.  
 The Application Inventory will allow applications to be linked to control entities within [tackle-controls](https://github.com/konveyor/tackle-controls) and manage the relationships between applications.  
-The Application Inventory is the gateway to applications assessment (via [tackle-pathfinder](https://github.com/konveyor/tackle-pathfinder)) and analysis (via [windup](https://github.com/windup/)).
+The Application Inventory is the gateway to applications assessment (via [tackle-pathfinder](https://github.com/konveyor/tackle-pathfinder)) and analysis (via [windup](https://github.com/windup/)).  
 
-## Development
+Further information in the following guides:
 
-### Required components
-
-#### PostgreSQL
-
-First start a PostreSQL container in [Podman](https://podman.io/) executing:
-```Shell
-$ podman run -it --rm=true --memory-swappiness=0 \
-            --name postgres-application-inventory -e POSTGRES_USER=application_inventory \
-            -e POSTGRES_PASSWORD=application_inventory -e POSTGRES_DB=application_inventory_db \
-            -p 5432:5432 postgres:10.6
-```
-It works the same with Docker just replacing `podman` with `docker` in the above command.
-
-#### Keycloak
-
-```Shell
-$ podman run -it --name keycloak --rm \
-            -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -e KEYCLOAK_IMPORT=/tmp/keycloak/quarkus-realm.json \
-            -e DB_VENDOR=h2 -p 8180:8080 -p 8543:8443 -v ./src/main/resources/keycloak:/tmp/keycloak:Z \
-            jboss/keycloak:12.0.2
-```
-
-### Run the application in dev mode
-
-You can run your application in dev mode that enables live coding using:
-```Shell
-$ ./mvnw quarkus:dev
-```
-
-### Call endpoints in dev mode
-
-To do calls to application's endpoint while running it in dev mode, execute the following commands:
-```Shell
-$ export access_token=$(\
-    curl -X POST http://localhost:8180/auth/realms/quarkus/protocol/openid-connect/token \
-    --user backend-service:secret \
-    -H 'content-type: application/x-www-form-urlencoded' \
-    -d 'username=alice&password=alice&grant_type=password' | jq --raw-output '.access_token' \
- )
-$ curl -X GET 'http://localhost:8080/application-inventory/application?description=ser&sort=name' \
-  -H 'Accept: application/json' -H "Authorization: Bearer "$access_token |jq .
-```
-
-## Test
-
-### Test coverage
-
-To get the report of test coverage of the application's code it's a matter of activating the `coverage` Maven profile during `verify` Maven goal execution like in the following command:
-```shell
-$ ./mvnw verify -Pjacoco
-```
-
-at the end the report will be available opening in a browser the `target/site/jacoco-ut/index.html` file.
-
-## Database management
-
-> :rotating_light: Backup and Restore instructions are provided for development purposes and **NOT for production** usage :rotating_light:
-
-### Backup
-
-1. get the name of the PostgreSQL pod:
-   ```shell
-   $ kubectl get pods -l app.kubernetes.io/name=application-inventory-postgres -n tackle
-   ```
-1. retrieve the database's user using pod's name (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv`):
-   ```shell
-   $ kubectl exec application-inventory-postgres-7cf456bdb9-lxhjv -n tackle -- printenv POSTGRES_USER
-   ```
-1. dump the database **data only** (excluding `flyway_schema_history` table) using pod's name and database's user (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv` and `application_inventory`):
-   ```shell
-   $ kubectl exec application-inventory-postgres-7cf456bdb9-lxhjv -n tackle  -- /bin/bash -c "pg_dump -a -T flyway_schema_history -U application_inventory application_inventory_db" > $(date +%Y%m%d%H%M%S)_application_inventory_db_data.sql
-   ```
-
-### Restore
-
-1. get the name of the PostgreSQL pod:
-   ```shell
-   $ kubectl get pods -l app.kubernetes.io/name=application-inventory-postgres -n tackle
-   ```
-1. retrieve the database's user using pod's name (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv`):
-   ```shell
-   $ kubectl exec application-inventory-postgres-7cf456bdb9-lxhjv -n tackle -- printenv POSTGRES_USER
-   ```
-1. insert the values in the database using pod's name and database's user (e.g. `application-inventory-postgres-7cf456bdb9-lxhjv` and `application_inventory`):
-   ```shell
-   $ cat 20210323195709_application_inventory_db_data.sql | kubectl exec -i application-inventory-postgres-7cf456bdb9-lxhjv -n tackle -- psql -U application_inventory -d application_inventory_db
-   ```
+* [development](DEVELOPMENT.md)
+* [usage](USAGE.md)

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,50 @@
+# Usage
+
+This guide provides basic guidance for interacting with API available in the Tackle Applicaiton Inventory REST endpoints.  
+
+## `/application` endpoint
+
+TBD  
+
+## `/applications-dependency` endpoint
+
+### Add a northbound dependency to an application
+To add the application with id `<dependency_id>` as a northbound dependency for the application with id `<application_id>` do a `POST` call to the `/applications-dependency` resource with the payload:  
+
+```json
+{
+    "from": {
+        "id": <dependency_id>
+    },
+    "to": {
+        "id": <application_id>
+    }
+}
+```
+
+### Add a southbound dependency to an application
+To add the application with id `<dependency_id>` as a southbound dependency for the application with id `<application_id>` do a `POST` call to the `/applications-dependency` resource with the payload:
+
+```json
+{
+    "from": {
+        "id": <application_id>
+    },
+    "to": {
+        "id": <dependency_id>
+    }
+}
+```
+
+### Retrieve northbound dependencies for an application
+To retrieve the set of the northbound dependencies for an application with id `<application_id>` do a `GET` call to the `/applications-dependency` resource with the query parameter `to.id=<application_id>`.  
+
+### Retrieve southbound dependencies for an application
+To retrieve the set of the northbound dependencies for an application with id `<application_id>` do a `GET` call to the `/applications-dependency` resource with the query parameter `from.id=<application_id>`.  
+
+### Delete a dependency
+To delete the applications' dependency with id `<applications_dependency_id>` do a `DELETE` call to the `/applications-dependency/<applications_dependency_id>` endpoint.  
+
+### Update a dependency
+Updating a dependency doesn't make sense because it would mean changing at least one of the applications involved and that would represent a different dependency.  
+For this reason the `PUT` HTTP verb on the `/applications-dependency` resource is not allowed.  

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <jacoco.version>0.8.6</jacoco.version>
     <quarkus.package.type>jar</quarkus.package.type>
     <keycloak.version>12.0.3</keycloak.version>
+    <jgrapht.version>1.5.1</jgrapht.version>
   </properties>
 
   <repositories>
@@ -107,6 +108,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-keycloak-authorization</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jgrapht</groupId>
+      <artifactId>jgrapht-core</artifactId>
+      <version>${jgrapht.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.konveyor.tackle-commons-rest</groupId>

--- a/src/main/java/io/tackle/applicationinventory/entities/Application.java
+++ b/src/main/java/io/tackle/applicationinventory/entities/Application.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.Where;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity
 @Table(name = "application")
@@ -21,4 +22,23 @@ public class Application extends AbstractEntity {
     public String businessService;
     @Filterable
     public String comments;
+
+    /**
+     * equals and hashCode methods overridden for being able to use this bean with the {@link org.jgrapht.Graph}
+     * in the {@link io.tackle.applicationinventory.entities.ApplicationsDependency#preChangesCheck()}
+     * considering it's mandatory to have to address the "logical equality" of Application beans
+     * which is based exclusively on the id value because all of the other fields can change for a bean.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Application)) return false;
+        Application that = (Application) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/io/tackle/applicationinventory/entities/ApplicationsDependency.java
+++ b/src/main/java/io/tackle/applicationinventory/entities/ApplicationsDependency.java
@@ -1,0 +1,93 @@
+package io.tackle.applicationinventory.entities;
+
+import io.quarkus.panache.common.Sort;
+import io.tackle.commons.annotations.Filterable;
+import io.tackle.commons.entities.AbstractEntity;
+import org.hibernate.annotations.ResultCheckStyle;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.cycle.CycleDetector;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Entity
+@Table(
+        name = "applications_dependency",
+        uniqueConstraints = @UniqueConstraint( columnNames = { "from_id", "to_id" } )
+)
+@SQLDelete(sql = "UPDATE applications_dependency SET deleted = true WHERE id = ?", check = ResultCheckStyle.COUNT)
+@Where(clause = "deleted = false")
+public class ApplicationsDependency extends AbstractEntity {
+    @ManyToOne
+    // in this bean, since the 'uniqueConstraints' has been specified,
+    // it's safer to ensure the constraint column names are declared
+    @JoinColumn(name = "from_id")
+    @Filterable(filterName = "from.id")
+    // it's the caller, the dependant, the northbound side
+    public Application from;
+
+    @ManyToOne
+    // in this bean, since the 'uniqueConstraints' has been specified,
+    // it's safer to ensure the constraint column names are declared
+    @JoinColumn(name = "to_id")
+    @Filterable(filterName = "to.id")
+    // it's the responder, the dependency, the southbound side
+    public Application to;
+    
+    @PrePersist
+    @PreUpdate
+    public void preChangesCheck() {
+        // validate input data
+        if (from == null || to == null) throw new BadRequestException("Not valid application reference provided");
+        // "self-loop" for dependencies is not allowed
+        if (from.equals(to)) throw new WebApplicationException("'from' and 'to' values are the same: an application can not be a dependency of itself", Response.Status.CONFLICT);
+        // applications must be already in the DB
+        Application fromApplication = Application.findById(from.id);
+        if (fromApplication == null) throw new NotFoundException(String.format("Not found the application with id %s", from.id));
+        Application toApplication = Application.findById(to.id);
+        if (toApplication == null) throw new NotFoundException(String.format("Not found the application with id %s", to.id));
+
+        // create the graph
+        Graph<Application, DefaultEdge> graph = GraphTypeBuilder.<Application, DefaultEdge>
+                directed()
+                .edgeClass(DefaultEdge.class)
+                .allowingSelfLoops(false)
+                .allowingMultipleEdges(false)
+                .weighted(false)
+                .buildGraph();
+
+        // load current data from DB that must be fine (i.e. without cycles) by definition
+        try (Stream<ApplicationsDependency> dependencies = ApplicationsDependency.streamAll(Sort.by("id"))) {
+            dependencies.forEach(applicationsDependency -> Graphs.addEdgeWithVertices(graph, applicationsDependency.from, applicationsDependency.to));
+        }
+        // add the dependency
+        Graphs.addEdgeWithVertices(graph, fromApplication, toApplication);
+
+        // check if it creates an cycle
+        CycleDetector<Application, DefaultEdge> cycleDetector = new CycleDetector<>(graph);
+        if (cycleDetector.detectCycles()) {
+            final String message = cycleDetector.findCyclesContainingVertex(fromApplication)
+                    .stream()
+                    .map(application -> application.name)
+                    .collect(Collectors.joining("', '", "Dependencies cycle created from applications '", "'"));
+            throw new WebApplicationException(message, Response.Status.CONFLICT);
+        }
+    }
+
+}

--- a/src/main/java/io/tackle/applicationinventory/resources/ApplicationsDependencyListFilteredResource.java
+++ b/src/main/java/io/tackle/applicationinventory/resources/ApplicationsDependencyListFilteredResource.java
@@ -1,0 +1,48 @@
+package io.tackle.applicationinventory.resources;
+
+import io.tackle.applicationinventory.entities.ApplicationsDependency;
+import io.tackle.commons.resources.ListFilteredResource;
+import org.jboss.resteasy.links.LinkResource;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+
+@Path("applications-dependency")
+public class ApplicationsDependencyListFilteredResource implements ListFilteredResource<ApplicationsDependency> {
+
+    @Override
+    public Class<ApplicationsDependency> getPanacheEntityType() {
+        return ApplicationsDependency.class;
+    }
+
+    @GET
+    @Path("")
+    @Produces({"application/json"})
+    @LinkResource(
+            entityClassName = "io.tackle.applicationinventory.entities.ApplicationsDependency",
+            rel = "list"
+    )
+    public Response list(@QueryParam(QUERY_PARAM_SORT) @DefaultValue(DEFAULT_VALUE_SORT) List var1,
+                         @QueryParam(QUERY_PARAM_PAGE) @DefaultValue(DEFAULT_VALUE_PAGE) int var2,
+                         @QueryParam(QUERY_PARAM_SIZE) @DefaultValue(DEFAULT_VALUE_SIZE) int var3,
+                         @Context UriInfo var4) throws Exception {
+        return ListFilteredResource.super.list(var1, var2, var3, var4, false);
+    }
+
+    @Path("")
+    @GET
+    @Produces({"application/hal+json"})
+    public Response listHal(@QueryParam(QUERY_PARAM_SORT) @DefaultValue(DEFAULT_VALUE_SORT) List var1,
+                            @QueryParam(QUERY_PARAM_PAGE) @DefaultValue(DEFAULT_VALUE_PAGE) int var2,
+                            @QueryParam(QUERY_PARAM_SIZE) @DefaultValue(DEFAULT_VALUE_SIZE) int var3,
+                            @Context UriInfo var4) throws Exception {
+        return ListFilteredResource.super.list(var1, var2, var3, var4, true);
+    }
+}

--- a/src/main/java/io/tackle/applicationinventory/resources/ApplicationsDependencyResource.java
+++ b/src/main/java/io/tackle/applicationinventory/resources/ApplicationsDependencyResource.java
@@ -1,0 +1,22 @@
+package io.tackle.applicationinventory.resources;
+
+import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.quarkus.rest.data.panache.MethodProperties;
+import io.quarkus.rest.data.panache.ResourceProperties;
+import io.tackle.applicationinventory.entities.ApplicationsDependency;
+
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+@ResourceProperties(hal = true)
+public interface ApplicationsDependencyResource extends PanacheEntityResource<ApplicationsDependency, Long> {
+    @MethodProperties(exposed = false)
+    List<ApplicationsDependency> list(Page page, Sort sort);
+
+    // updating a dependency doesn't make sense because it would mean changing
+    // at least one of the applications involved and that represents a different dependency
+    @MethodProperties(exposed = false)
+    Response update(Long id);
+}

--- a/src/main/java/io/tackle/applicationinventory/resources/ResourcesExceptionHandler.java
+++ b/src/main/java/io/tackle/applicationinventory/resources/ResourcesExceptionHandler.java
@@ -1,0 +1,18 @@
+package io.tackle.applicationinventory.resources;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * ExceptionMapper created to provide a customized message for WebApplicationException
+ * when REST method implementations come from PanacheEntityResource.
+ */
+@Provider
+public class ResourcesExceptionHandler implements ExceptionMapper<WebApplicationException> {
+    @Override
+    public Response toResponse(WebApplicationException exception) {
+        return Response.status(exception.getResponse().getStatus()).entity(exception.getMessage()).build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,9 +16,9 @@ quarkus.datasource.password = application_inventory
 quarkus.datasource.jdbc.url = jdbc:postgresql://application-inventory-postgresql:5432/application_inventory_db
 #quarkus.hibernate-orm.jdbc.timezone = UTC
 # Query logging enabled in every env but prod
-quarkus.hibernate-orm.log.sql=true
-%prod.quarkus.hibernate-orm.log.sql=false
-quarkus.hibernate-orm.log.bind-parameters=true
+%dev.quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.log.sql=false
+%dev.quarkus.hibernate-orm.log.bind-parameters=true
 # bind-parameters (BasicBinder) is at TRACE so min-level must be configured properly
 %dev.quarkus.log.category."org.hibernate.type.descriptor.sql.BasicBinder".min-level=FINER
 %dev.quarkus.log.category."org.hibernate.type.descriptor.sql.BasicBinder".level=FINER

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ quarkus.datasource.password = application_inventory
 %local.quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5432/application_inventory_db
 quarkus.datasource.jdbc.url = jdbc:postgresql://application-inventory-postgresql:5432/application_inventory_db
 #quarkus.hibernate-orm.jdbc.timezone = UTC
-# Query logging enabled in every env but prod
+# Query logging disabled in every env but dev
 %dev.quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.log.sql=false
 %dev.quarkus.hibernate-orm.log.bind-parameters=true

--- a/src/main/resources/db/migration/V20210325.1__create_applications-dependency.sql
+++ b/src/main/resources/db/migration/V20210325.1__create_applications-dependency.sql
@@ -1,0 +1,21 @@
+create table applications_dependency (
+    id int8 not null,
+    createTime timestamp,
+    createUser varchar(255),
+    deleted boolean,
+    updateTime timestamp,
+    updateUser varchar(255),
+    from_id int8,
+    to_id int8,
+    primary key (id)
+);
+alter table if exists applications_dependency
+    add constraint UKlgwufxhgndoa6198mawite3fo unique (from_id, to_id);
+alter table if exists applications_dependency
+    add constraint FKfwaxbxio04nk2gj90ssf8p82f
+    foreign key (from_id)
+    references application;
+alter table if exists applications_dependency
+    add constraint FKlracllg4jlktabdvo2mp41hhj
+    foreign key (to_id)
+    references application;

--- a/src/main/resources/db/test-data/V20210325.2__insert_applications-dependency.sql
+++ b/src/main/resources/db/test-data/V20210325.2__insert_applications-dependency.sql
@@ -1,0 +1,2 @@
+INSERT INTO applications_dependency (id, from_id, to_id, deleted) VALUES (nextval('hibernate_sequence'), 1, 2, false);
+INSERT INTO applications_dependency (id, from_id, to_id, deleted) VALUES (nextval('hibernate_sequence'), 2, 3, false);

--- a/src/main/resources/db/test-data/V20210326__insert_application.sql
+++ b/src/main/resources/db/test-data/V20210326__insert_application.sql
@@ -1,0 +1,1 @@
+INSERT INTO application (id, name, description, deleted) VALUES (nextval('hibernate_sequence'), 'Test Application', 'Test Application for applications dependencies', false);

--- a/src/main/resources/import-dev.sql
+++ b/src/main/resources/import-dev.sql
@@ -1,3 +1,6 @@
 INSERT INTO application (id, name, description, deleted) VALUES (nextval('hibernate_sequence'), 'Home Banking BU', 'Important service to let private customer use their home banking accounts', false);
 INSERT INTO application (id, name, description, deleted) VALUES (nextval('hibernate_sequence'), 'Online Investments service', 'Corporate customers investments management', false);
 INSERT INTO application (id, name, description, deleted) VALUES (nextval('hibernate_sequence'), 'Credit Cards BS', 'Internal credit card creation and management service', false);
+INSERT INTO applications_dependency (id, from_id, to_id, deleted) VALUES (nextval('hibernate_sequence'), 1, 2, false);
+INSERT INTO applications_dependency (id, from_id, to_id, deleted) VALUES (nextval('hibernate_sequence'), 1, 3, false);
+INSERT INTO applications_dependency (id, from_id, to_id, deleted) VALUES (nextval('hibernate_sequence'), 3, 2, false);

--- a/src/test/java/io/tackle/applicationinventory/entities/ApplicationTest.java
+++ b/src/test/java/io/tackle/applicationinventory/entities/ApplicationTest.java
@@ -1,0 +1,54 @@
+package io.tackle.applicationinventory.entities;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ApplicationTest {
+
+    @Test
+    public void testEquals() {
+        Application x = new Application();
+        x.id = 0L;
+        Application y = new Application();
+        y.id = 0L;
+        Application z = new Application();
+        z.id = 0L;
+        ApplicationsDependency ad = new ApplicationsDependency();
+        ad.id = 0L;
+        // Reflexive
+        assertEquals(x, x);
+        // Symmetric
+        assertEquals(x.equals(y), y.equals(x));
+        assertEquals(x.equals(ad), ad.equals(x));
+        // Transitive
+        assertEquals(x.equals(y) && y.equals(z), x.equals(z));
+        // Consistent
+        assertEquals(x, y);
+        y.name = "y";
+        y.description = "y";
+        y.comments = "y";
+        assertEquals(x, y);
+        // Non-nullity
+        assertFalse(x.equals(null));
+
+        assertNotEquals( "test", z);
+    }
+
+    @Test
+    public void testHashCode() {
+        Application x = new Application();
+        x.id = 0L;
+        int initial = x.hashCode();
+        x.name = "x";
+        x.description = "x";
+        x.comments = "x";
+        assertEquals(initial, x.hashCode());
+        Application y = new Application();
+        y.id = 0L;
+        assertEquals(x, y);
+        assertEquals(x.hashCode(), y.hashCode());
+    }
+}

--- a/src/test/java/io/tackle/applicationinventory/resources/ApplicationTest.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/ApplicationTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
                 @ResourceArg(name = KeycloakTestResource.REALM_NAME, value = "quarkus")
         }
 )
-public class ApplicationResourceTest extends SecuredResourceTest {
+public class ApplicationTest extends SecuredResourceTest {
 
     @BeforeAll
     public static void init() {
@@ -41,6 +41,6 @@ public class ApplicationResourceTest extends SecuredResourceTest {
                 .when().get(PATH)
                 .then()
                 .statusCode(200)
-                .body("_embedded.application.comments[0].length()", is(1000));
+                .body("_embedded.application.comments[1].length()", is(1000));
     }
 }

--- a/src/test/java/io/tackle/applicationinventory/resources/ApplicationsDependencyTest.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/ApplicationsDependencyTest.java
@@ -1,0 +1,360 @@
+package io.tackle.applicationinventory.resources;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.tackle.applicationinventory.entities.Application;
+import io.tackle.applicationinventory.entities.ApplicationsDependency;
+import io.tackle.commons.testcontainers.KeycloakTestResource;
+import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
+import io.tackle.commons.tests.SecuredResourceTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
+        initArgs = {
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.DB_NAME, value = "application_inventory_db"),
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.USER, value = "application_inventory"),
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.PASSWORD, value = "application_inventory")
+        }
+)
+@QuarkusTestResource(value = KeycloakTestResource.class,
+        initArgs = {
+                @ResourceArg(name = KeycloakTestResource.IMPORT_REALM_JSON_PATH, value = "keycloak/quarkus-realm.json"),
+                @ResourceArg(name = KeycloakTestResource.REALM_NAME, value = "quarkus")
+        }
+)
+// different approach to tests using an ordered set of test methods
+// due to the fact the dependencies tests need quite a lot of data
+// that depends on each other and to test cycles a very specific situation
+// must be created in a determinist way.
+// The test order numbering approach is kind of BASIC C64 line numbering approach:
+// incrementing by 10 between tests to let some room for further later tests additions
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ApplicationsDependencyTest extends SecuredResourceTest {
+
+    private static final Application TEST_APPLICATION = new Application();
+    // 1000 applications has been reported as a kind of worst case scenario
+    // so it's worth testing the behavior in such condition
+    // => check 'applications-dependencies-test' in .github/workflows/pull_request.yml
+    private static int numberOfApplications;
+
+    @BeforeAll
+    public static void beforeAll() {
+        PATH = "/applications-dependency";
+        TEST_APPLICATION.id = 6L; // from 'V20210326__insert_application.sql'
+        numberOfApplications = Integer.parseInt(System.getProperty("dependencies.test.applications", "10"));
+    }
+
+    @Test
+    @Order(0)
+    public void testCreateApplications() {
+        IntStream.range(0, numberOfApplications).forEach(i -> {
+            Application application = new Application();
+            application.name = String.format("Application Test %d", i);
+            application.description = String.format("Application Test description %d", i);
+            application.comments = String.format("Application Test comments %d", i);
+            given()
+                    .contentType(ContentType.JSON)
+                    .accept(ContentType.JSON)
+                    .body(application)
+                    .when()
+                    .post("/application")
+                    .then()
+                    .statusCode(201);
+        });
+    }
+
+    @Test
+    @Order(10)
+    public void testCreateApplicationsDependencies() {
+        // retrieve the id of the first application added in the previous method
+        long firstApplicationId = Long.parseLong(given()
+                .queryParam("name", "test 0")
+                .accept(ContentType.JSON)
+                .when()
+                .get("/application")
+                .then()
+                .statusCode(200)
+                .body("size()", is(1))
+                .extract()
+                .path("[0].id")
+                .toString());
+
+        IntStream.range(0, numberOfApplications).forEach(i -> {
+            final Application application = new Application();
+            application.id = (long) i + firstApplicationId;
+            ApplicationsDependency dependency = new ApplicationsDependency();
+            // even iterations create southbound dependencies for TEST_APPLICATION
+            if ((i % 2) == 0) {
+                dependency.from = TEST_APPLICATION;
+                dependency.to = application;
+            }
+            // odd iterations create northbound dependencies for TEST_APPLICATION
+            else {
+                dependency.from = application;
+                dependency.to = TEST_APPLICATION;
+            }
+            given()
+                    .contentType(ContentType.JSON)
+                    .accept(ContentType.JSON)
+                    .body(dependency)
+                    .when()
+                    .post(PATH)
+                    .then()
+                    .statusCode(201);
+        });
+
+        // test the cycle detector creating a cycle
+        // considering with already have the dependencies:
+        // * 'Home Banking BU' => 'Online Investments service' => 'Credit Cards BS'
+        //    (from 'V20210325.2__insert_applications-dependency.sql')
+        // * 'Application Test 1' => 'Test Application' => 'Application Test 0'
+        //    (from the above dependencies creation loop)
+        // Now we create two further dependencies:
+        // 1. from southbound dependency 'Application Test 0' to 'Home Banking BU'
+        // 2. from 'Credit Cards BS' to northbound dependency 'Application Test 1'
+        // so that the loop with 6 applications should be detected
+        // that tries to connect 2 previously disconnected graphs
+        Application from = new Application();
+        Application to = new Application();
+
+        ApplicationsDependency firstDependency = new ApplicationsDependency();
+        from.id = firstApplicationId; // 'Application Test 0'
+        to.id = 1L; // 'Home Banking BU' from 'V20210305.2__insert_application.sql'
+        firstDependency.from = from;
+        firstDependency.to = to;
+        firstDependency.id = Long.parseLong(given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(firstDependency)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(201)
+        .extract()
+        .path("id")
+        .toString());
+
+        ApplicationsDependency cycle = new ApplicationsDependency();
+        from.id = 3L; // 'Credit Cards BS' from 'V20210305.2__insert_application.sql'
+        to.id = firstApplicationId + 1L; // 'Application Test 1'
+        cycle.from = from;
+        cycle.to = to;
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(cycle)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(409)
+                .body(is("Dependencies cycle created from applications 'Credit Cards BS', 'Application Test 1', 'Test Application', 'Application Test 0', 'Home Banking BU', 'Online Investments service'"));
+
+        // now that the cycle detection has been tested successfully
+        // it's fine to remove the 'firstDependency'
+        given()
+                .pathParam("id", firstDependency.id)
+                .when()
+                .delete(PATH + "/{id}")
+                .then()
+                .statusCode(204);
+    }
+    
+    @Test
+    @Order(15)
+    public void testRetrieveNorthboundDependencies() {
+        given()
+                .accept("application/hal+json")
+                .queryParam("to.id", TEST_APPLICATION.id)
+                .queryParam("size", numberOfApplications)
+                .queryParam("sort", "id")
+                .when()
+                .get(PATH)
+                .then()
+                .statusCode(200)
+                .body("_embedded.applications-dependency.size()", is(numberOfApplications / 2));
+    }
+
+    @Test
+    @Order(16)
+    public void testRetrieveSouthboundDependencies() {
+        given()
+                .accept("application/hal+json")
+                .queryParam("from.id", TEST_APPLICATION.id)
+                .queryParam("size", numberOfApplications)
+                .queryParam("sort", "id")
+                .when()
+                .get(PATH)
+                .then()
+                .statusCode(200)
+                .body("_embedded.applications-dependency.size()", is(numberOfApplications / 2));
+    }
+
+    @Test
+    @Order(20)
+    public void testCreateApplicationsDependenciesWithWrongValues() {
+        ApplicationsDependency dependency = new ApplicationsDependency();
+        Application frontend = new Application();
+        frontend.id = 2L;
+        dependency.from = frontend;
+        Application db = new Application();
+        db.id = 1L;
+        dependency.to = db;
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(dependency)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(409)
+                .body(is("Dependencies cycle created from applications 'Online Investments service', 'Home Banking BU'"));
+
+        db.id = 2L;
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(dependency)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(409)
+                .body(is("'from' and 'to' values are the same: an application can not be a dependency of itself"));
+
+        db.id = 98765L;
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(dependency)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(404)
+                .body(is("Not found the application with id 98765"));
+
+        frontend.id = 12345L;
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(dependency)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(404)
+                .body(is("Not found the application with id 12345"));
+
+        dependency.to = null;
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(dependency)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(400)
+                .body(is("Not valid application reference provided"));
+
+        dependency.from = null;
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(dependency)
+                .when()
+                .post(PATH)
+                .then()
+                .statusCode(400)
+                .body(is("Not valid application reference provided"));
+    }
+
+    @Test
+    @Order(30)
+    public void testDeleteApplicationsDependencies() {
+        Response response = given()
+                .queryParam("from.id", "6")
+                .queryParam("size", numberOfApplications)
+                .accept(ContentType.JSON)
+                .when()
+                .get(PATH)
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+        List<Integer> ids = response.path("id");
+
+        response = given()
+                .queryParam("to.id", "6")
+                .queryParam("size", numberOfApplications)
+                .accept(ContentType.JSON)
+                .when()
+                .get(PATH)
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+        ids.addAll(response.path("id"));
+        
+        assertEquals(numberOfApplications, ids.size());
+
+        ids.forEach(id -> {
+            given()
+                    .pathParam("id", id)
+                    .when()
+                    .delete(PATH + "/{id}")
+                    .then()
+                    .statusCode(204);
+        });
+    }
+
+    @Test
+    @Order(40)
+    public void testDeleteApplications() {
+        long firstApplicationId = Long.parseLong(given()
+                .queryParam("name", "test 0")
+                .accept(ContentType.JSON)
+                .when()
+                .get("/application")
+                .then()
+                .statusCode(200)
+                .body("size()", is(1))
+                .extract()
+                .path("[0].id")
+                .toString());
+
+        IntStream.range((int) firstApplicationId, (int) firstApplicationId + numberOfApplications).forEach(i -> given()
+                .pathParam("id", i)
+                .when()
+                .delete("/application/{id}")
+                .then()
+                .statusCode(204));
+    }
+
+    @Test
+    // test not order because it can be executed whenever
+    public void testUpdateNotAllowed() {
+        ApplicationsDependency dependency = new ApplicationsDependency();
+        dependency.id = 1L;
+        given()
+                .contentType(ContentType.JSON)
+                .pathParam("id", dependency.id)
+                .body(dependency)
+                .when()
+                .put(PATH + "/{id}")
+                .then()
+                .statusCode(405);
+    }
+}

--- a/src/test/java/io/tackle/applicationinventory/resources/NativeApplicationIT.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/NativeApplicationIT.java
@@ -1,0 +1,7 @@
+package io.tackle.applicationinventory.resources;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeApplicationIT extends ApplicationTest {
+}

--- a/src/test/java/io/tackle/applicationinventory/resources/NativeApplicationsDependencyIT.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/NativeApplicationsDependencyIT.java
@@ -1,0 +1,7 @@
+package io.tackle.applicationinventory.resources;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeApplicationsDependencyIT extends ApplicationsDependencyTest {
+}

--- a/src/test/java/io/tackle/applicationinventory/resources/ServicesParameterizedTest.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/ServicesParameterizedTest.java
@@ -3,6 +3,11 @@ package io.tackle.applicationinventory.resources;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.tackle.applicationinventory.entities.Application;
+import io.tackle.applicationinventory.entities.ApplicationsDependency;
+import io.tackle.commons.entities.AbstractEntity;
 import io.tackle.commons.testcontainers.KeycloakTestResource;
 import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
 import io.tackle.commons.tests.SecuredResourceTest;
@@ -11,14 +16,18 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.converter.SimpleArgumentConverter;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
+import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
@@ -37,37 +46,78 @@ import static org.hamcrest.Matchers.is;
 public class ServicesParameterizedTest extends SecuredResourceTest {
 
     // the 'name' output seems not to work with Quarkus
-    @DisplayName("testListHalEndpoint")
+    @DisplayName("testListEndpoints")
     @ParameterizedTest(name = "{index} ==> Resource ''{0}'' tested is {1}")
     @CsvSource({
-            "application, 3, 1::2::3, name, Home Banking BU::Online Investments service::Credit Cards BS, 2, 3"
+        //   resource path          , size, IDs       , tot, pageLinksSize, entityLinksSize, anotherField, anotherFieldValues
+            "application            ,    4, 1::2::3::6,   4,             4,               5,         name, Home Banking BU::Online Investments service::Credit Cards BS",
+            "applications-dependency,    2,       4::5,   2,             4,               4,    from.name, Home Banking BU::Online Investments service"
     })
-    public void testListHalEndpoint(String resource, int size, @ConvertWith(CSVtoArray.class) Integer[] ids,
-                                    String anotherFieldName, @ConvertWith(CSVtoArray.class) String[] anotherFieldValues,
-                                    int selfId, int totalCount) {
+    public void testListEndpoints(String resource, int size, @ConvertWith(CSVtoArray.class) Integer[] ids,
+                                  int totalCount, int pageLinksSize, int entityLinksSize,
+                                  String anotherFieldName, @ConvertWith(CSVtoArray.class) String[] anotherFieldValues) {
         given()
                 .accept("application/hal+json")
                 .queryParam("sort", "id")
-                .when().get(resource)
+                .queryParam("size", "5")
+                .when()
+                .get(resource)
                 .then()
                 .statusCode(200)
                 .body(String.format("_embedded.%s.size()", resource), is(size),
                         String.format("_embedded.%s.id", resource), containsInRelativeOrder(ids),
                         String.format("_embedded.%s.%s", resource, anotherFieldName), containsInRelativeOrder(anotherFieldValues),
-                        String.format("_embedded.%s[1]._links.size()", resource), is(5),
-                        String.format("_embedded.%s[1]._links.self.href", resource), is(String.format("http://localhost:8081/application-inventory/%s/%d", resource, selfId)),
+                        String.format("_embedded.%s[1]._links.size()", resource), is(entityLinksSize),
+                        String.format("_embedded.%s[1]._links.self.href", resource), is(String.format("http://localhost:8081/application-inventory/%s/%d", resource, ids[1])),
                         String.format("_embedded._metadata.totalCount", resource), is(totalCount),
-                        "_links.size()", is(4));
+                        "_links.size()", is(pageLinksSize));
 
         given()
                 .accept("application/json")
                 .queryParam("sort", "id")
-                .when().get(resource)
+                .queryParam("size", "5")
+                .when()
+                .get(resource)
                 .then()
                 .statusCode(200)
                 .body(String.format("size()", resource), is(size),
                         String.format("id", resource), containsInRelativeOrder(ids),
                         String.format("%s", anotherFieldName), containsInRelativeOrder(anotherFieldValues));
+    }
+
+    @ParameterizedTest(name = "{index} ==> Resource ''{0}'' tested is {1}")
+    @MethodSource("provideObjects")
+    public void testCreateAndDeleteEndpoint(AbstractEntity entity, String resource) {
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(entity)
+                .when()
+                .post(resource)
+                .then()
+                .statusCode(201)
+                .extract()
+                .response();
+
+        assertEquals("alice", response.path("createUser"));
+        assertEquals("alice", response.path("updateUser"));
+
+        Integer entityId = response.path("id");
+
+        given()
+                .pathParam("id", entityId)
+                .when()
+                .delete(format("%s/{id}", resource))
+                .then()
+                .statusCode(204);
+
+        given()
+                .accept("application/json")
+                .pathParam("id", entityId)
+                .when()
+                .get(format("%s/{id}", resource))
+                .then()
+                .statusCode(404);
     }
 
     public static class CSVtoArray extends SimpleArgumentConverter {
@@ -77,6 +127,27 @@ public class ServicesParameterizedTest extends SecuredResourceTest {
             if (targetType.isAssignableFrom(Integer[].class)) return stream.map(Integer::valueOf).toArray(Integer[]::new);
             else return stream.toArray(String[]::new);
         }
+    }
+
+    private static Stream<Arguments> provideObjects() {
+        Application application = new Application();
+        application.name = "tackle";
+        application.description = "Tackle helps you modernize your applications.";
+        application.businessService = "123";
+        application.comments = "Tackle application needs even some comments";
+
+        ApplicationsDependency dependency = new ApplicationsDependency();
+        Application frontend = new Application();
+        frontend.id = 1L;
+        dependency.from = frontend;
+        Application db = new Application();
+        db.id = 3L;
+        dependency.to = db;
+
+        return Stream.of(
+                Arguments.of(application, "/application"),
+                Arguments.of(dependency, "/applications-dependency")
+        );
     }
 
 }


### PR DESCRIPTION
resolve #11 

- introduced [`jgrapht`](https://jgrapht.org/) to manage dependencies graph
- added `ResourcesExceptionHandler` to be able to provide custom messages to errors sent in responses
- added a specific `applications-dependencies-test` job to test application dependencies with 1000 applications (reported as a worst case scenario)
- to provide information on how to use the new endpoints, I divided the `README` into 
   - [`DEVELOPMENT` guide](https://github.com/mrizzi/tackle-application-inventory/blob/11-add-dependencies-management/DEVELOPMENT.md) which contains most of the content previously in the `README`
   - [`USAGE` guide](https://github.com/mrizzi/tackle-application-inventory/blob/11-add-dependencies-management/USAGE.md) to explain how to call REST endpoint and with which parameters
