### PR TITLE
Database schema validation during tests

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,7 @@ quarkus.hibernate-orm.log.sql=false
 # use 'update' to generate SQL scripts, validate them and then create a new file into resources/db/migration folder
 %dev.quarkus.hibernate-orm.database.generation = drop-and-create
 %dev.quarkus.hibernate-orm.sql-load-script = import-dev.sql
+%test.quarkus.hibernate-orm.database.generation = validate
 # DO NOT REMOVE/CHANGE. Make sure to not drop our database in production!
 %prod.quarkus.hibernate-orm.database.generation = none
 %prod.quarkus.hibernate-orm.sql-load-script = no-file


### PR DESCRIPTION
resolve #35

introduced the schema validation during tests.
It has not been added to `prod` profile to avoid, as agreed, any kind of interaction with the production database by Hibernate ORM database generation.
Obviously tests are mandatory to succeed to have a new `prod` profile image created so the validation is reliable to guarantee the consistency between Java entities and DB schema.