### PR TITLE
[Tackle-234/236] Fix issues with Adoption Plan

### DIFF
--- a/src/main/java/io/tackle/applicationinventory/services/ReportService.java
+++ b/src/main/java/io/tackle/applicationinventory/services/ReportService.java
@@ -45,7 +45,7 @@ public class ReportService {
             })
             .filter(a -> EffortEstimate.isExists(((Application) a).review.effortEstimate)) // The review has a valid Effort
             .map(e -> buildAdoptionPlanAppDto(applicationIds, reversedGraph, (Application) e))
-            .sorted(Comparator.comparing(e -> String.format("%06d", e.positionY) + e.applicationName))
+            .sorted(Comparator.comparing(e -> String.format("%06d", ((AdoptionPlanAppDto) e).positionY) + ((AdoptionPlanAppDto) e).applicationName).reversed())
             .collect(Collectors.toList());
 
         // adjusting the positionY value to it's real order

--- a/src/main/java/io/tackle/applicationinventory/services/ReportService.java
+++ b/src/main/java/io/tackle/applicationinventory/services/ReportService.java
@@ -99,22 +99,17 @@ public class ReportService {
     }
 
     private Integer startPositionNode(EdgeReversedGraph<Application, DefaultEdge> graph, Application application, List<Long> selectedApps) {
-        List<Application> parents = Graphs.successorListOf(graph, application);
+        List<Application> parents = Graphs.predecessorListOf(graph, application);
         if (parents.size() > 0) {
             return parents.stream().map(e -> {
                 // recursively we'll find the position calculating previous positions + lengths of the ancestors
                 Integer pos = startPositionNode(graph, e, selectedApps);
                 // if the parent is an application selected to appear in the list then we use its effort, otherwise is like we are hiding it with effort = 0
-                Integer effort;
-                if (EffortEstimate.isExists(e.review.effortEstimate))  {
-                    effort = (selectedApps.contains(e.id)) ? EffortEstimate.getEnum(e.review.effortEstimate).getEffort() : 0;
-                } else {
-                    effort = 0; // to not affect the PositionX
-                }
+                Integer effort = (e.review != null && EffortEstimate.isExists(e.review.effortEstimate) && selectedApps.contains(e.id)) ? EffortEstimate.getEnum(e.review.effortEstimate).getEffort() : 0;
                 return pos + effort;
             })
-                .max(Integer::compare).get();
-            // Selecting the largest position from its ancestors
+            .max(Integer::compare).get();
+            // Selecting the largest position from its predecessors
         } else {
             // point of return for the recursivity on Top nodes
             return 0;

--- a/src/test/java/io/tackle/applicationinventory/resources/ReportsResourceTest.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/ReportsResourceTest.java
@@ -46,12 +46,12 @@ class ReportsResourceTest extends ReportTestUtil {
         .then()
             .log().all()
             .body("size()", is(10))
-            .body("find{it.applicationName=='App19'}.positionX", is(16))
+            .body("find{it.applicationName=='App19'}.positionX", is(0))
             .body("find{it.applicationName=='App19'}.decision", is("Refactor"))
             .body("find{it.applicationName=='App19'}.effortEstimate", is("Extra_Large"))
             .body("find{it.applicationName=='App19'}.positionY", is(9))
             .body("find{it.applicationName=='App19'}.effort", is(8))
-            .body("find{it.applicationName=='App16'}.positionX", is(1))
+            .body("find{it.applicationName=='App16'}.positionX", is(8))
             .body("find{it.applicationName=='App16'}.positionY", is(7));
     }
 

--- a/src/test/java/io/tackle/applicationinventory/resources/ReportsResourceTest.java
+++ b/src/test/java/io/tackle/applicationinventory/resources/ReportsResourceTest.java
@@ -49,10 +49,10 @@ class ReportsResourceTest extends ReportTestUtil {
             .body("find{it.applicationName=='App19'}.positionX", is(0))
             .body("find{it.applicationName=='App19'}.decision", is("Refactor"))
             .body("find{it.applicationName=='App19'}.effortEstimate", is("Extra_Large"))
-            .body("find{it.applicationName=='App19'}.positionY", is(9))
+            .body("find{it.applicationName=='App19'}.positionY", is(0))
             .body("find{it.applicationName=='App19'}.effort", is(8))
             .body("find{it.applicationName=='App16'}.positionX", is(8))
-            .body("find{it.applicationName=='App16'}.positionY", is(7));
+            .body("find{it.applicationName=='App16'}.positionY", is(2));
     }
 
 }

--- a/src/test/java/io/tackle/applicationinventory/services/ReportServiceTest.java
+++ b/src/test/java/io/tackle/applicationinventory/services/ReportServiceTest.java
@@ -46,13 +46,13 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(10);
 
         // checking first app
-        assertPlanDto(applicationPlanDtoList, "App10", 0, 1, "Rehost", 3);
+        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 3);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 4);
         // checking intermediate app
-        assertPlanDto(applicationPlanDtoList, "App15", 4, 4, "Replatform", 6);
+        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 6);
 
         // checking last app
-        assertPlanDto(applicationPlanDtoList, "App19", 16, 8, "Refactor", 9);
+        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 9);
     }
 
     @Test
@@ -69,12 +69,12 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(9);
 
         // checking first apps
-        assertPlanDto(applicationPlanDtoList, "App10", 0, 1, "Rehost", 2);
+        assertPlanDto(applicationPlanDtoList, "App10", 22, 1, "Rehost", 2);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 3);
         // checking intermediate app
-        assertPlanDto(applicationPlanDtoList, "App15", 3, 4, "Replatform", 5);
+        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 5);
         // checking last app
-        assertPlanDto(applicationPlanDtoList, "App19", 15, 8, "Refactor", 8);
+        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 8);
     }
 
     @Test
@@ -88,7 +88,7 @@ class ReportServiceTest extends ReportTestUtil {
             .collect(Collectors.toList());
         appList.addAll(initialApps);
 
-        Application app19 = Application.find("name", "App19").firstResult();
+        Application app10 = Application.find("name", "App10").firstResult();
         int totalApplications = 2000;
         for (int i = 20; i < totalApplications; i++) {
             Application app = new Application();
@@ -111,8 +111,8 @@ class ReportServiceTest extends ReportTestUtil {
             app.review = review;
 
             ApplicationsDependency dependency = new ApplicationsDependency();
-            dependency.from = app19;
-            dependency.to = app;
+            dependency.to = app10;
+            dependency.from = app;
             dependency.persistAndFlush();
             appList.add(app.id);
         }
@@ -126,13 +126,13 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(totalApplications-10);
 
         // checking 10,14 apps
-        assertPlanDto(applicationPlanDtoList, "App10", 0, 1, "Rehost", 3);
+        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 3);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 4);
 
         // checking 15 app
-        assertPlanDto(applicationPlanDtoList, "App15", 4, 4, "Replatform", 6);
+        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 6);
         // checking 19 app
-        assertPlanDto(applicationPlanDtoList, "App19", 16, 8, "Refactor", 9);
+        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 9);
 
         // checking 20 app
         assertPlanDto(applicationPlanDtoList, "App20", 24, 1, "Replatform", 10);

--- a/src/test/java/io/tackle/applicationinventory/services/ReportServiceTest.java
+++ b/src/test/java/io/tackle/applicationinventory/services/ReportServiceTest.java
@@ -46,13 +46,13 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(10);
 
         // checking first app
-        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 3);
-        assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 4);
+        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 6);
+        assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 5);
         // checking intermediate app
-        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 6);
+        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 3);
 
         // checking last app
-        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 9);
+        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 0);
     }
 
     @Test
@@ -69,12 +69,13 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(9);
 
         // checking first apps
-        assertPlanDto(applicationPlanDtoList, "App10", 22, 1, "Rehost", 2);
-        assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 3);
+        assertPlanDto(applicationPlanDtoList, "App10", 22, 1, "Rehost", 6);
+        assertPlanDto(applicationPlanDtoList, "App11", 0, 8, "Refactor", 8);
+        assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 5);
         // checking intermediate app
-        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 5);
+        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 3);
         // checking last app
-        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 8);
+        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 0);
     }
 
     @Test
@@ -104,7 +105,7 @@ class ReportServiceTest extends ReportTestUtil {
             review.businessCriticality = 1;
             review.comments = "";
             review.proposedAction = "Replatform";
-            review.workPriority = i;
+            review.workPriority = 0;
             review.application = app;
             review.persistAndFlush();
 
@@ -126,35 +127,35 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(totalApplications-10);
 
         // checking 10,14 apps
-        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 3);
-        assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 4);
+        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 6);
+        assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 5);
 
         // checking 15 app
-        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 6);
+        assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 3);
         // checking 19 app
-        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 9);
+        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 0);
 
         // checking 20 app
-        assertPlanDto(applicationPlanDtoList, "App20", 24, 1, "Replatform", 10);
+        assertPlanDto(applicationPlanDtoList, "App20", 24, 1, "Replatform", null);
 
         // checking 100 app
         if (totalApplications > 100) {
-            assertPlanDto(applicationPlanDtoList, "App100", 24, 1, "Replatform", 90);
+            assertPlanDto(applicationPlanDtoList, "App100", 24, 1, "Replatform", null);
         }
 
         // checking 500 app
         if (totalApplications > 500) {
-            assertPlanDto(applicationPlanDtoList, "App500", 24, 1, "Replatform", 490);
+            assertPlanDto(applicationPlanDtoList, "App500", 24, 1, "Replatform", null);
         }
 
         // checking 1000 app
         if (totalApplications > 1000) {
-            assertPlanDto(applicationPlanDtoList, "App1000", 24, 1, "Replatform", 990);
+            assertPlanDto(applicationPlanDtoList, "App1000", 24, 1, "Replatform", null);
         }
 
         // checking 1500 app
         if (totalApplications > 1500) {
-            assertPlanDto(applicationPlanDtoList, "App1500", 24, 1, "Replatform", 1490);
+            assertPlanDto(applicationPlanDtoList, "App1500", 24, 1, "Replatform", null);
         }
     }
 
@@ -211,20 +212,28 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(9);
 
         // checking first app App15 has not sum its effort as it doesnt have review
-        assertPlanDto(applicationPlanDtoList, "App10", 19, 1, "Rehost", 3);
+        assertPlanDto(applicationPlanDtoList, "App10", 19, 1, "Rehost", 5);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 4);
 
         // App15 doesnt appear in the output as it doesnt have review
         assertThat(applicationPlanDtoList.stream().filter(a -> a.applicationName.equalsIgnoreCase("App15")).count()).isEqualTo(0);
 
         // checking last app
-        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 8);
+        assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 0);
     }
 
-    private void assertPlanDto(List<AdoptionPlanAppDto> applicationPlanDtoList, String app, int expected_positionX, int expected_effort, String expected_decision, int expected_posy) {
-        assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().positionX).isEqualTo(expected_positionX);
-        assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().effort).isEqualTo(expected_effort);
-        assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().decision).isEqualTo(expected_decision);
-        assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().positionY).isEqualTo(expected_posy);
+    private void assertPlanDto(List<AdoptionPlanAppDto> applicationPlanDtoList, String app, Integer expected_positionX, Integer expected_effort, String expected_decision, Integer expected_posy) {
+        if (expected_positionX != null ) {
+            assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().positionX).isEqualTo(expected_positionX);
+        }
+        if (expected_effort != null) {
+            assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().effort).isEqualTo(expected_effort);
+        }
+        if (expected_decision != null) {
+            assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().decision).isEqualTo(expected_decision);
+        }
+        if (expected_posy != null) {
+            assertThat(applicationPlanDtoList.stream().filter(e -> e.applicationName.equalsIgnoreCase(app)).findFirst().get().positionY).isEqualTo(expected_posy);
+        }
     }
 }

--- a/src/test/java/io/tackle/applicationinventory/services/ReportServiceTest.java
+++ b/src/test/java/io/tackle/applicationinventory/services/ReportServiceTest.java
@@ -46,10 +46,11 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(10);
 
         // checking first app
-        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 6);
+        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 4);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 5);
         // checking intermediate app
         assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 3);
+        assertPlanDto(applicationPlanDtoList, "App13", 21, 2, "Refactor", 9);
 
         // checking last app
         assertPlanDto(applicationPlanDtoList, "App19", 0, 8, "Refactor", 0);
@@ -69,8 +70,9 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(9);
 
         // checking first apps
-        assertPlanDto(applicationPlanDtoList, "App10", 22, 1, "Rehost", 6);
-        assertPlanDto(applicationPlanDtoList, "App11", 0, 8, "Refactor", 8);
+        assertPlanDto(applicationPlanDtoList, "App10", 22, 1, "Rehost", 4);
+        assertPlanDto(applicationPlanDtoList, "App11", 0, 8, "Refactor", 7);
+        assertPlanDto(applicationPlanDtoList, "App13", 20, 2, "Refactor", 8);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 5);
         // checking intermediate app
         assertPlanDto(applicationPlanDtoList, "App15", 16, 4, "Replatform", 3);
@@ -127,7 +129,7 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(totalApplications-10);
 
         // checking 10,14 apps
-        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 6);
+        assertPlanDto(applicationPlanDtoList, "App10", 23, 1, "Rehost", 4);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 5);
 
         // checking 15 app
@@ -212,7 +214,7 @@ class ReportServiceTest extends ReportTestUtil {
         assertThat(applicationPlanDtoList).hasSize(9);
 
         // checking first app App15 has not sum its effort as it doesnt have review
-        assertPlanDto(applicationPlanDtoList, "App10", 19, 1, "Rehost", 5);
+        assertPlanDto(applicationPlanDtoList, "App10", 19, 1, "Rehost", 3);
         assertPlanDto(applicationPlanDtoList, "App14", 0, 1, "Rehost", 4);
 
         // App15 doesnt appear in the output as it doesnt have review


### PR DESCRIPTION
Issues : Tackle-234 and Tackle-236

Fixes : 
* flipped the dependency concept (inbound/outbound)
* flipped the priority concept (descendent order)
* added check on the parents regarding having a review
* changing the vertical sort to be : DESC Priority ASC App Name

### Result
![image](https://user-images.githubusercontent.com/1836434/121720521-80aadb80-cae3-11eb-8ad7-a8028fcb5001.png)


