### PR TITLE
[TACKLE-311] - REST Pods shut down over time for Tackle instance deployed on Openshift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,12 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.platform.version>1.13.1.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.13.7.Final</quarkus.platform.version>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
 <!--    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>-->
 <!--    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>-->
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus-plugin.version>1.13.1.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.13.7.Final</quarkus-plugin.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <testcontainers.version>1.16.0</testcontainers.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/TACKLE-311

This PR is complementary to https://github.com/konveyor/tackle-controls/pull/189 and in order to understand the problem and how to reproduce it, please follow the same instructions described at https://github.com/konveyor/tackle-controls/pull/189